### PR TITLE
Listen port globally

### DIFF
--- a/burning-pro-server/src/bin/burning-pro-server.rs
+++ b/burning-pro-server/src/bin/burning-pro-server.rs
@@ -61,7 +61,8 @@ fn main() {
         env!("CARGO_PKG_VERSION")
     );
 
-    let listen = "127.0.0.1:8080";
+    // TODO: Use config file to determine address and port to listen.
+    let listen = "0.0.0.0:8080";
 
     let sys = actix::System::new("burning-pro-server");
 


### PR DESCRIPTION
`127.0.0.1:8080` を listen していると、コンテナ内で起動したときコンテナ外からのアクセスを受け付けなくてﾊｲという感じになってしまう。
この PR で、あらゆるホストからの `8080` ポートへのアクセスを受け入れるようになる。