### PR TITLE
Silence diesel warnings which would be fixed in diesel-1.4

### DIFF
--- a/burning-pro-server/src/db/upsert_entry.rs
+++ b/burning-pro-server/src/db/upsert_entry.rs
@@ -1,5 +1,9 @@
 //! Types for upsert query.
 
+// Temporal silence until diesel-1.4.
+// See <https://github.com/diesel-rs/diesel/issues/1785#issuecomment-422579609>.
+#![allow(proc_macro_derive_resolution_fallback)]
+
 use actix::prelude::*;
 use chrono::{DateTime, Local};
 use diesel;

--- a/burning-pro-server/src/models/mod.rs
+++ b/burning-pro-server/src/models/mod.rs
@@ -1,4 +1,9 @@
 //! Models.
+
+// Temporal silence until diesel-1.4.
+// See <https://github.com/diesel-rs/diesel/issues/1785#issuecomment-422579609>.
+#![allow(proc_macro_derive_resolution_fallback)]
+
 use chrono::NaiveDateTime;
 
 use schema::*;

--- a/burning-pro-server/src/models/update.rs
+++ b/burning-pro-server/src/models/update.rs
@@ -1,5 +1,9 @@
 //! Data types insertable to DB.
 
+// Temporal silence until diesel-1.4.
+// See <https://github.com/diesel-rs/diesel/issues/1785#issuecomment-422579609>.
+#![allow(proc_macro_derive_resolution_fallback)]
+
 use chrono::NaiveDateTime;
 
 use schema::*;

--- a/burning-pro-server/src/schema.rs
+++ b/burning-pro-server/src/schema.rs
@@ -1,3 +1,7 @@
+// Temporal silence until diesel-1.4.
+// See <https://github.com/diesel-rs/diesel/issues/1785#issuecomment-422579609>.
+#![allow(proc_macro_derive_resolution_fallback)]
+
 table! {
     good_phrase_tags (good_phrase_tag_id) {
         good_phrase_tag_id -> Integer,


### PR DESCRIPTION
This is temporary workaround.
See <https://github.com/diesel-rs/diesel/issues/1785#issuecomment-422579609>.

これでビルド時に滝のように流れてくる警告をなくせます