### PR TITLE
Remove CI build and test for nightly rustc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,5 @@ cache: cargo
 rust:
   - stable
   - beta
-  - nightly
-matrix:
-  allow_failures:
-    - rust: nightly
 notifications:
   email: false


### PR DESCRIPTION
We don't need such a strong future-proofness. Trying with stable and
beta is sufficient.