### PR TITLE
Use the latest stable Rust

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.29
+FROM rust:1.30
 
 WORKDIR /usr/src/burning-pro-server
 COPY burning-pro-server burning-pro-server


### PR DESCRIPTION
We are already using the latest stable Rust (1.30) by CI.
There is no reason to stick with older compiler.