### PR TITLE
Make listen address and port configurable

### DIFF
--- a/burning-pro-server/src/bin/burning-pro-server.rs
+++ b/burning-pro-server/src/bin/burning-pro-server.rs
@@ -114,8 +114,16 @@ fn main() {
         env!("CARGO_PKG_VERSION")
     );
 
-    // TODO: Use config file to determine address and port to listen.
-    let listen = "0.0.0.0:8080";
+    // To provide safe default, this should not be `0.0.0.0:*`.
+    const LISTEN_DEFAULT: &str = "localhost:8080";
+    let listen = match env::var("LISTEN") {
+        Ok(v) => v,
+        Err(env::VarError::NotPresent) => LISTEN_DEFAULT.into(),
+        Err(e) => {
+            error!("Envvar `$LISTEN` has invalid value: {}", e);
+            panic!("Envvar `$LISTEN` has invalid value: {}", e);
+        }
+    };
 
     let sys = actix::System::new("burning-pro-server");
 
@@ -168,7 +176,7 @@ fn main() {
                         ),
                     )
             })
-    }).bind(listen)
+    }).bind(&listen)
     .unwrap_or_else(|e| {
         panic!("Failed to bind {}: {}", listen, e);
     }).start();

--- a/burning-pro-server/template.env
+++ b/burning-pro-server/template.env
@@ -3,6 +3,12 @@
 # This should be a path of the SQLite3 file.
 DATABASE_URL=./db.sqlite3
 
+# Address and port to listen (optional).
+#
+# Default is `localhost:8080`.
+# You might want to use `0.0.0.0:80` to run the server in production environment.
+#LISTEN=0.0.0.0:80
+
 # Admin web UI auth config.
 ADMIN_WEB_USER=CHANGEME_USERNAME
 ADMIN_WEB_PASSWORD=CHANGEME_PASSWORD


### PR DESCRIPTION
Additionally, the default address and port to listen is changed to a safer one (`localhost:8080`).

This branch is based on #43, and should be merged after that.
(When #43 is merged, this branch should be rebased onto `develop` and WIP label would be unset.)